### PR TITLE
Vary the weight of food items relative to their integrity.

### DIFF
--- a/src/main/java/org/dungeon/game/Weight.java
+++ b/src/main/java/org/dungeon/game/Weight.java
@@ -56,12 +56,12 @@ public class Weight implements Comparable<Weight>, Serializable {
   }
 
   /**
-   * Produces a new Weight object representing p percent of this object's weight.
+   * Produces a new Weight object by multiplying this object with percentage p.
    *
    * @param p a Percentage object
    * @return a Weight object representing the relative value
    */
-  public Weight percentageOf(Percentage p) {
+  public Weight multiplyBy(Percentage p) {
     return newInstance(this.value * p.toDouble());
   }
 

--- a/src/main/java/org/dungeon/game/Weight.java
+++ b/src/main/java/org/dungeon/game/Weight.java
@@ -18,6 +18,7 @@
 package org.dungeon.game;
 
 import org.dungeon.io.DLogger;
+import org.dungeon.util.Percentage;
 
 import java.io.Serializable;
 
@@ -52,6 +53,16 @@ public class Weight implements Comparable<Weight>, Serializable {
    */
   public Weight add(Weight o) {
     return newInstance(this.value + o.value);
+  }
+
+  /**
+   * Produces a new Weight object representing p percent of this object's weight.
+   *
+   * @param p a Percentage object
+   * @return a Weight object representing the relative value
+   */
+  public Weight percentageOf(Percentage p) {
+    return newInstance(this.value * p.toDouble());
   }
 
   public String toString() {

--- a/src/main/java/org/dungeon/items/Item.java
+++ b/src/main/java/org/dungeon/items/Item.java
@@ -21,6 +21,7 @@ import org.dungeon.game.Engine;
 import org.dungeon.game.Entity;
 import org.dungeon.game.Game;
 import org.dungeon.game.Weight;
+import org.dungeon.util.Percentage;
 
 public class Item extends Entity {
 
@@ -64,7 +65,12 @@ public class Item extends Entity {
   }
 
   public Weight getWeight() {
-    return weight;
+    if (isFood()) {
+      Percentage integrityPercentage = new Percentage(curIntegrity / (double) maxIntegrity);
+      return weight.percentageOf(integrityPercentage);
+    } else {
+      return weight;
+    }
   }
 
   public String getQualifiedName() {

--- a/src/main/java/org/dungeon/items/Item.java
+++ b/src/main/java/org/dungeon/items/Item.java
@@ -67,7 +67,7 @@ public class Item extends Entity {
   public Weight getWeight() {
     if (isFood()) {
       Percentage integrityPercentage = new Percentage(curIntegrity / (double) maxIntegrity);
-      return weight.percentageOf(integrityPercentage);
+      return weight.multiplyBy(integrityPercentage);
     } else {
       return weight;
     }


### PR DESCRIPTION
Closes #81.

Adds percentageOf() to Weight.
Makes Item.getWeight() return integrity-proportional weight for food.

Raises possible issue of really long, ugly weight strings ONLY if future food items fail to have nice, evenly divisible integrity decrements. Seems unlikely, so putting in rounding preemptively seemed too heavy-handed.