### PR TITLE
Removed repeated occurrence of the unequip command

### DIFF
--- a/src/main/java/org/mafagafogigante/dungeon/commands/CommandSets.java
+++ b/src/main/java/org/mafagafogigante/dungeon/commands/CommandSets.java
@@ -291,12 +291,6 @@ final class CommandSets {
         Writer.write(new SystemInformation());
       }
     });
-    commandSet.addCommand(new Command("unequip", "Unequips the currently equipped item.") {
-      @Override
-      public void execute(@NotNull String[] arguments) {
-        Game.getGameState().getHero().unequipWeapon();
-      }
-    });
     return commandSet;
   }
 


### PR DESCRIPTION
It was present in both the default and extra command sets.

It should be part of the default command set.