### PR TITLE
Fixed style violations in JSON rule tests

### DIFF
--- a/src/test/java/org/mafagafogigante/dungeon/schema/rules/BoundIntegerJsonRuleTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/schema/rules/BoundIntegerJsonRuleTest.java
@@ -14,22 +14,22 @@ public class BoundIntegerJsonRuleTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void boundIntegerJsonRuleShouldFailWhenValueOutOfLowerBound() {
-    final int ltLowerBound = 1;
-    JsonValue jsonValue = Json.value(ltLowerBound);
+    final int lowerThanLowerBound = 1;
+    JsonValue jsonValue = Json.value(lowerThanLowerBound);
     boundIntegerJsonRule.validate(jsonValue);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void boundIntegerJsonRuleShouldFailWhenValueOutOfUpperBound() {
-    final int gtLowerBound = 6;
-    JsonValue jsonValue = Json.value(gtLowerBound);
+    final int greaterThanUpperBound = 6;
+    JsonValue jsonValue = Json.value(greaterThanUpperBound);
     boundIntegerJsonRule.validate(jsonValue);
   }
 
   @Test
   public void boundIntegerJsonRuleShouldPassWhenValueInBound() {
-    final int inBound = 3;
-    JsonValue jsonValue = Json.value(inBound);
+    final int valid = 3;
+    JsonValue jsonValue = Json.value(valid);
     boundIntegerJsonRule.validate(jsonValue);
   }
 

--- a/src/test/java/org/mafagafogigante/dungeon/schema/rules/DoubleJsonRuleTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/schema/rules/DoubleJsonRuleTest.java
@@ -4,17 +4,11 @@ import org.mafagafogigante.dungeon.schema.JsonRule;
 
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonValue;
-import org.junit.Before;
 import org.junit.Test;
 
 public class DoubleJsonRuleTest {
 
-  private JsonRule doubleJsonRule;
-
-  @Before
-  public void setUp() {
-    doubleJsonRule = new DoubleJsonRule();
-  }
+  private static final JsonRule doubleJsonRule = new DoubleJsonRule();
 
   @Test(expected = IllegalArgumentException.class)
   public void doubleJsonRuleShouldFailNonDoubleType() {

--- a/src/test/java/org/mafagafogigante/dungeon/schema/rules/IntegerJsonRuleTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/schema/rules/IntegerJsonRuleTest.java
@@ -4,17 +4,11 @@ import org.mafagafogigante.dungeon.schema.JsonRule;
 
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonValue;
-import org.junit.Before;
 import org.junit.Test;
 
 public class IntegerJsonRuleTest {
 
-  private JsonRule integerJsonRule;
-
-  @Before
-  public void setUp() {
-    integerJsonRule = new IntegerJsonRule();
-  }
+  private static final JsonRule integerJsonRule = new IntegerJsonRule();
 
   @Test(expected = IllegalArgumentException.class)
   public void integerJsonRuleShouldFailNonIntegerType() {


### PR DESCRIPTION
I have fixed some check style issues for files that were lost in 4e87e2f7ca67ddb47310366932ceb48b4aa125bf.