### PR TITLE
Minify JSON files using our own Maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
             <plugin>
                 <groupId>com.github.unknownnpc.plugins</groupId>
                 <artifactId>json-to-string-maven-plugin</artifactId>
-                <version>1.1</version>
+                <version>1.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,23 @@
                     <check/>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.github.unknownnpc.plugins</groupId>
+                <artifactId>json-to-string-maven-plugin</artifactId>
+                <version>1.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>minify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includes>
+                        <include>${project.build.directory}/classes/*.json</include>
+                    </includes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -168,8 +168,8 @@
             </plugin>
             <plugin>
                 <groupId>com.github.unknownnpc.plugins</groupId>
-                <artifactId>json-to-string-maven-plugin</artifactId>
-                <version>1.2</version>
+                <artifactId>json-compressor</artifactId>
+                <version>1.3</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
PR related to the ticket #338 and comment from PR #355:
> If we could develop a minimal Maven plugin that used our JSON parser to read and write the JSON sources (without any spaces) it would be great. Not only it would not break the JSON files, it would also be much more efficient and a lot safer.

I have finished the trivial one. Also, I have checked it on some large json files. 