### PR TITLE
EnumJsonRule and tests for enum values in JSON files

### DIFF
--- a/src/main/java/org/mafagafogigante/dungeon/game/LocationPreset.java
+++ b/src/main/java/org/mafagafogigante/dungeon/game/LocationPreset.java
@@ -106,6 +106,6 @@ public final class LocationPreset {
     this.blobSize = blobSize;
   }
 
-  enum Type {RIVER, BRIDGE, DUNGEON_ENTRANCE, DUNGEON_STAIRWAY, DUNGEON_ROOM, DUNGEON_CORRIDOR, LAND}
+  public enum Type {RIVER, BRIDGE, DUNGEON_ENTRANCE, DUNGEON_STAIRWAY, DUNGEON_ROOM, DUNGEON_CORRIDOR, LAND}
 
 }

--- a/src/main/java/org/mafagafogigante/dungeon/schema/rules/EnumJsonRule.java
+++ b/src/main/java/org/mafagafogigante/dungeon/schema/rules/EnumJsonRule.java
@@ -1,36 +1,28 @@
 package org.mafagafogigante.dungeon.schema.rules;
 
 import com.eclipsesource.json.JsonValue;
-import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 class EnumJsonRule<T extends Enum<T>> extends StringJsonRule {
 
-  private final List<Enum<T>> enumValues = new ArrayList<>();
+  private final Set<String> enumValues = new HashSet<>();
 
   EnumJsonRule(Class<T> enumClass) {
-    Collections.addAll(enumValues, enumClass.getEnumConstants());
+    for (Enum<T> enumConstant : enumClass.getEnumConstants()) {
+      enumValues.add(enumConstant.toString());
+    }
   }
 
   @Override
   public void validate(JsonValue value) {
     super.validate(value);
     String valueAsString = value.asString();
-    if (!isValueExist(valueAsString)) {
+    boolean isValueExist = enumValues.contains(valueAsString);
+    if (!isValueExist) {
       throw new IllegalArgumentException(valueAsString + " is not exist in next enum values: " + enumValues + ".");
     }
-  }
-
-  private boolean isValueExist(String value) {
-    for (Enum<T> enumValue : enumValues) {
-      if (StringUtils.equals(enumValue.toString(), value)) {
-        return true;
-      }
-    }
-    return false;
   }
 
 }

--- a/src/main/java/org/mafagafogigante/dungeon/schema/rules/EnumJsonRule.java
+++ b/src/main/java/org/mafagafogigante/dungeon/schema/rules/EnumJsonRule.java
@@ -1,0 +1,36 @@
+package org.mafagafogigante.dungeon.schema.rules;
+
+import com.eclipsesource.json.JsonValue;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class EnumJsonRule<T extends Enum<T>> extends StringJsonRule {
+
+  private final List<Enum<T>> enumValues = new ArrayList<>();
+
+  EnumJsonRule(Class<T> enumClass) {
+    Collections.addAll(enumValues, enumClass.getEnumConstants());
+  }
+
+  @Override
+  public void validate(JsonValue value) {
+    super.validate(value);
+    String valueAsString = value.asString();
+    if (!isValueExist(valueAsString)) {
+      throw new IllegalArgumentException(valueAsString + " is not exist in next enum values: " + enumValues + ".");
+    }
+  }
+
+  private boolean isValueExist(String value) {
+    for (Enum<T> enumValue : enumValues) {
+      if (StringUtils.equals(enumValue.toString(), value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+}

--- a/src/main/java/org/mafagafogigante/dungeon/schema/rules/JsonRuleFactory.java
+++ b/src/main/java/org/mafagafogigante/dungeon/schema/rules/JsonRuleFactory.java
@@ -75,4 +75,8 @@ public final class JsonRuleFactory {
     return new PeriodJsonRule();
   }
 
+  public static <T extends Enum<T>> JsonRule makeEnumJsonRule(Class<T> enumClass) {
+    return new EnumJsonRule<>(enumClass);
+  }
+
 }

--- a/src/test/java/org/mafagafogigante/dungeon/io/CreaturesJsonFileTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/io/CreaturesJsonFileTest.java
@@ -1,5 +1,7 @@
 package org.mafagafogigante.dungeon.io;
 
+import org.mafagafogigante.dungeon.entity.creatures.AttackAlgorithmId;
+import org.mafagafogigante.dungeon.entity.creatures.Creature.Tag;
 import org.mafagafogigante.dungeon.schema.JsonRule;
 import org.mafagafogigante.dungeon.schema.rules.JsonRuleFactory;
 
@@ -54,16 +56,16 @@ public class CreaturesJsonFileTest extends ResourcesTypeTest {
     final JsonRule idRule = JsonRuleFactory.makeIdRule();
     final JsonRule percentRule = JsonRuleFactory.makePercentRule();
     final JsonRule integerRule = JsonRuleFactory.makeIntegerRule();
-    final JsonRule uppercaseJsonRule = JsonRuleFactory.makeUppercaseStringRule();
     creatureRules.put(ID_FIELD, idRule);
     creatureRules.put(TYPE_FIELD, JsonRuleFactory.makeStringRule());
     creatureRules.put(NAME_FIELD, nameJsonRuleObject);
-    final JsonRule variableUppercaseRule = JsonRuleFactory.makeVariableArrayRule(uppercaseJsonRule);
-    creatureRules.put(TAGS_FIELD, JsonRuleFactory.makeOptionalRule(variableUppercaseRule));
+    JsonRule tagEnumRule = JsonRuleFactory.makeEnumJsonRule(Tag.class);
+    JsonRule variableTagEnumRule = JsonRuleFactory.makeVariableArrayRule(tagEnumRule);
+    creatureRules.put(TAGS_FIELD, JsonRuleFactory.makeOptionalRule(variableTagEnumRule));
     creatureRules.put(INVENTORY_ITEM_LIMIT_FIELD, JsonRuleFactory.makeOptionalRule(integerRule));
-    final JsonRule optionalIntegerRule = JsonRuleFactory.makeOptionalRule(integerRule);
+    JsonRule optionalIntegerRule = JsonRuleFactory.makeOptionalRule(integerRule);
     creatureRules.put(INVENTORY_WEIGHT_LIMIT_FIELD, optionalIntegerRule);
-    final JsonRule variableIdRule = JsonRuleFactory.makeVariableArrayRule(idRule);
+    JsonRule variableIdRule = JsonRuleFactory.makeVariableArrayRule(idRule);
     creatureRules.put(INVENTORY_FIELD, JsonRuleFactory.makeOptionalRule(variableIdRule));
     creatureRules.put(DROPS_FIELD, getDropsRule());
     creatureRules.put(LUMINOSITY_FIELD, JsonRuleFactory.makeOptionalRule(percentRule));
@@ -71,7 +73,8 @@ public class CreaturesJsonFileTest extends ResourcesTypeTest {
     creatureRules.put(WEIGHT_FIELD, JsonRuleFactory.makeBoundDoubleRule(Double.MIN_VALUE, Double.MAX_VALUE));
     creatureRules.put(HEALTH_FIELD, integerRule);
     creatureRules.put(ATTACK_FIELD, integerRule);
-    creatureRules.put(ATTACK_ALGORITHM_ID_FIELD, idRule);
+    JsonRule attackAlgorithmEnumRule = JsonRuleFactory.makeEnumJsonRule(AttackAlgorithmId.class);
+    creatureRules.put(ATTACK_ALGORITHM_ID_FIELD, attackAlgorithmEnumRule);
     creatureRules.put(WEAPON_FIELD, JsonRuleFactory.makeOptionalRule(idRule));
     return JsonRuleFactory.makeObjectRule(creatureRules);
   }

--- a/src/test/java/org/mafagafogigante/dungeon/io/ItemsJsonFileTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/io/ItemsJsonFileTest.java
@@ -1,5 +1,6 @@
 package org.mafagafogigante.dungeon.io;
 
+import org.mafagafogigante.dungeon.entity.items.Item;
 import org.mafagafogigante.dungeon.schema.JsonRule;
 import org.mafagafogigante.dungeon.schema.rules.JsonRuleFactory;
 
@@ -64,7 +65,8 @@ public class ItemsJsonFileTest extends ResourcesTypeTest {
     itemRules.put(ID_FIELD, idRule);
     itemRules.put(TYPE_FIELD, stringRule);
     itemRules.put(NAME_FIELD, nameRuleObject);
-    itemRules.put(TAGS_FIELD, JsonRuleFactory.makeVariableArrayRule(stringRule));
+    JsonRule itemTagEnumRule = JsonRuleFactory.makeEnumJsonRule(Item.Tag.class);
+    itemRules.put(TAGS_FIELD, JsonRuleFactory.makeVariableArrayRule(itemTagEnumRule));
     itemRules.put(UNIQUE_FIELD, JsonRuleFactory.makeOptionalRule(JsonRuleFactory.makeBooleanRule()));
     itemRules.put(INTEGRITY_FIELD, integrityRuleObject);
     itemRules.put(WEIGHT_FIELD, JsonRuleFactory.makeBoundDoubleRule(Double.MIN_VALUE, 100));

--- a/src/test/java/org/mafagafogigante/dungeon/io/LocationsJsonFileTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/io/LocationsJsonFileTest.java
@@ -1,5 +1,6 @@
 package org.mafagafogigante.dungeon.io;
 
+import org.mafagafogigante.dungeon.game.LocationPreset;
 import org.mafagafogigante.dungeon.schema.JsonRule;
 import org.mafagafogigante.dungeon.schema.rules.JsonRuleFactory;
 
@@ -55,7 +56,8 @@ public class LocationsJsonFileTest extends ResourcesTypeTest {
     final JsonRule blobBoundRule = JsonRuleFactory.makeBoundIntegerRule(BLOB_SIZE_MIN, BLOB_SIZE_MAX);
     final JsonRule lightBoundRule = JsonRuleFactory.makeBoundDoubleRule(PERMITTIVITY_MIN, PERMITTIVITY_MAX);
     locationsRules.put(ID_FIELD, idRule);
-    locationsRules.put(TYPE_FIELD, idRule);
+    JsonRule locationTypeEnumRule = JsonRuleFactory.makeEnumJsonRule(LocationPreset.Type.class);
+    locationsRules.put(TYPE_FIELD, locationTypeEnumRule);
     locationsRules.put(NAME_FIELD, nameRule);
     locationsRules.put(COLOR_FIELD, colorRule);
     locationsRules.put(SYMBOL_FIELD, JsonRuleFactory.makeStringLengthRule(SYMBOL_STRING_LENGTH));

--- a/src/test/java/org/mafagafogigante/dungeon/schema/rules/EnumJsonRuleTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/schema/rules/EnumJsonRuleTest.java
@@ -1,0 +1,49 @@
+package org.mafagafogigante.dungeon.schema.rules;
+
+import org.mafagafogigante.dungeon.schema.JsonRule;
+
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonValue;
+import org.junit.Test;
+
+public class EnumJsonRuleTest {
+
+  private static final String INVALID_ENUM_VALUE_UPPERCASE = "TWO";
+  private static final String INVALID_ENUM_VALUE_LOWERCASE = "one";
+  private static final JsonRule enumJsonRule = new EnumJsonRule<>(TestEnum.class);
+
+  @Test
+  public void enumJsonRuleShouldPassValidEnumValue() {
+    JsonValue jsonValue = Json.value(TestEnum.ONE.toString());
+    enumJsonRule.validate(jsonValue);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void enumJsonRuleShouldFailOnNonExistEnumValue() {
+    JsonValue jsonValue = Json.value(INVALID_ENUM_VALUE_UPPERCASE);
+    enumJsonRule.validate(jsonValue);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void enumJsonRuleShouldFailOnNonStringValue() {
+    JsonValue jsonValue = Json.value(true);
+    enumJsonRule.validate(jsonValue);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void enumJsonRuleShouldFailOnLowercaseValue() {
+    JsonValue jsonValue = Json.value(INVALID_ENUM_VALUE_LOWERCASE);
+    enumJsonRule.validate(jsonValue);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void enumJsonRuleShouldFailOnEmptyValue() {
+    JsonValue jsonValue = Json.value("");
+    enumJsonRule.validate(jsonValue);
+  }
+
+  private enum TestEnum {
+    ONE
+  }
+
+}


### PR DESCRIPTION
PR is related to the issue #357. 
Commit contains `EnumJsonRule` class and `io` tests updates for next fields:

- creatures.json
`tags`
`attackAlgorithm`
- items.json
`tags`
- locations.json
`type`