### PR TITLE
Should have hero statistics for sleep, damage, resting and healing

### DIFF
--- a/src/main/java/org/mafagafogigante/dungeon/date/Date.java
+++ b/src/main/java/org/mafagafogigante/dungeon/date/Date.java
@@ -20,7 +20,7 @@ public class Date implements Comparable<Date>, Serializable {
    */
   private long time; // Supports 1067519911 full years.
 
-  private Date(long millis) {
+  public Date(long millis) {
     time = millis;
   }
 

--- a/src/main/java/org/mafagafogigante/dungeon/entity/creatures/Creature.java
+++ b/src/main/java/org/mafagafogigante/dungeon/entity/creatures/Creature.java
@@ -27,6 +27,7 @@ public class Creature extends Entity {
   private final CreatureInventory inventory;
   private final LightSource lightSource;
   private final CreatureHealth health;
+  private final CreatureBattleDamage battleDamage;
   private final Dropper dropper;
   private final Observer observer = new Observer(this);
   private Item weapon;
@@ -50,6 +51,7 @@ public class Creature extends Entity {
     inventory = new CreatureInventory(this, preset.getInventoryItemLimit(), preset.getInventoryWeightLimit());
     lightSource = new LightSource(preset.getLuminosity());
     dropper = new Dropper(this, preset.getDropList());
+    battleDamage = new CreatureBattleDamage();
   }
 
   public boolean hasTag(Tag tag) {
@@ -58,6 +60,10 @@ public class Creature extends Entity {
 
   public CreatureHealth getHealth() {
     return health;
+  }
+
+  public CreatureBattleDamage getBattleDamage() {
+    return battleDamage;
   }
 
   Dropper getDropper() {

--- a/src/main/java/org/mafagafogigante/dungeon/entity/creatures/CreatureBattleDamage.java
+++ b/src/main/java/org/mafagafogigante/dungeon/entity/creatures/CreatureBattleDamage.java
@@ -1,0 +1,61 @@
+package org.mafagafogigante.dungeon.entity.creatures;
+
+import java.io.Serializable;
+
+/**
+ * The damage counters of a creature.
+ */
+public class CreatureBattleDamage implements Serializable {
+
+  private long receivedCount;
+  private long inflictedCount;
+
+  /**
+   * Increments the received damage by the specified amount.
+   *
+   * @param receivedDamage a nonnegative long
+   */
+  public void incrementReceived(long receivedDamage) {
+    this.receivedCount += receivedDamage;
+  }
+
+  /**
+   * Increments the inflicted damage by the specified amount.
+   *
+   * @param inflictedDamage a nonnegative long
+   */
+  public void incrementInflicted(long inflictedDamage) {
+    this.inflictedCount += inflictedDamage;
+  }
+
+  /**
+   * Gets and resets received damage count.
+   */
+  public long getAndResetReceivedCount() {
+    try {
+      return receivedCount;
+    } finally {
+      receivedCount = 0L;
+    }
+  }
+
+  /**
+   * Gets and resets inflicted damage count.
+   */
+  public long getAndResetInflictedCount() {
+    try {
+      return inflictedCount;
+    } finally {
+      inflictedCount = 0L;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "CreatureBattleDamage{" +
+        "receivedCount=" + receivedCount +
+        ", inflictedCount=" + inflictedCount +
+        '}';
+  }
+
+}

--- a/src/main/java/org/mafagafogigante/dungeon/entity/creatures/CreatureFactory.java
+++ b/src/main/java/org/mafagafogigante/dungeon/entity/creatures/CreatureFactory.java
@@ -1,6 +1,5 @@
 package org.mafagafogigante.dungeon.entity.creatures;
 
-import org.mafagafogigante.dungeon.achievements.AchievementTracker;
 import org.mafagafogigante.dungeon.date.Date;
 import org.mafagafogigante.dungeon.entity.items.CreatureInventory.SimulationResult;
 import org.mafagafogigante.dungeon.entity.items.Item;
@@ -115,7 +114,7 @@ public final class CreatureFactory implements Serializable {
   public Hero makeHero(Date date, World world, Statistics statistics) {
     DateOfBirthGenerator dateOfBirthGenerator = new DateOfBirthGenerator(date, 30);
     Date dateOfBirth = dateOfBirthGenerator.generateDateOfBirth();
-    Hero hero = new Hero(creaturePresets.get(new Id("HERO")), new AchievementTracker(statistics), dateOfBirth);
+    Hero hero = new Hero(creaturePresets.get(new Id("HERO")), statistics, dateOfBirth);
     giveItems(hero, world);
     return hero;
   }

--- a/src/main/java/org/mafagafogigante/dungeon/entity/creatures/Hero.java
+++ b/src/main/java/org/mafagafogigante/dungeon/entity/creatures/Hero.java
@@ -26,6 +26,7 @@ import org.mafagafogigante.dungeon.io.Sleeper;
 import org.mafagafogigante.dungeon.io.Writer;
 import org.mafagafogigante.dungeon.spells.Spell;
 import org.mafagafogigante.dungeon.spells.SpellData;
+import org.mafagafogigante.dungeon.stats.Statistics;
 import org.mafagafogigante.dungeon.util.DungeonMath;
 import org.mafagafogigante.dungeon.util.Matches;
 import org.mafagafogigante.dungeon.util.Messenger;
@@ -67,11 +68,13 @@ public class Hero extends Creature {
   private final Observer observer = new Observer(this);
   private final Spellcaster spellcaster = new HeroSpellcaster(this);
   private final AchievementTracker achievementTracker;
+  private final Statistics statistics;
   private final Date dateOfBirth;
 
-  Hero(CreaturePreset preset, AchievementTracker achievementTracker, Date dateOfBirth) {
+  Hero(CreaturePreset preset, Statistics statistics, Date dateOfBirth) {
     super(preset);
-    this.achievementTracker = achievementTracker;
+    this.statistics = statistics;
+    this.achievementTracker = new AchievementTracker(statistics);
     this.dateOfBirth = dateOfBirth;
   }
 
@@ -93,6 +96,7 @@ public class Hero extends Creature {
    */
   private void addHealth(int amount) {
     getHealth().incrementBy(amount);
+    statistics.getHeroStatistics().incrementHealByEatCount(amount);
     if (getHealth().isFull()) {
       Writer.write("You are completely healed.");
     }
@@ -111,6 +115,7 @@ public class Hero extends Creature {
       // Therefore, the following expression may evaluate to 0 if we do not use Math.max to secure the call to
       // Engine.rollDateAndRefresh.
       int timeResting = Math.max(1, healthRecovered * SECONDS_TO_REGENERATE_FULL_HEALTH / getHealth().getMaximum());
+      statistics.getHeroStatistics().incrementRestTimeCount(timeResting);
       Engine.rollDateAndRefresh(timeResting);
       Writer.write("Resting...");
       getHealth().incrementBy(healthRecovered);
@@ -137,7 +142,9 @@ public class Hero extends Creature {
         Engine.rollDateAndRefresh(cycleDuration);
         // Cast to long because it is considered best practice. We are going to end with a long anyway, so start doing
         // long arithmetic at the first multiplication. Reported by ICAST_INTEGER_MULTIPLY_CAST_TO_LONG in FindBugs.
-        Sleeper.sleep((long) MILLISECONDS_TO_SLEEP_AN_HOUR * cycleDuration / HOUR.as(SECOND));
+        long timeForSleep = (long) MILLISECONDS_TO_SLEEP_AN_HOUR * cycleDuration / HOUR.as(SECOND);
+        Sleeper.sleep(timeForSleep);
+        statistics.getHeroStatistics().incrementSleepTimeCount(timeForSleep);
         if (cycleDuration == DREAM_DURATION_IN_SECONDS) {
           Writer.write(Libraries.getDreamLibrary().next());
         }

--- a/src/main/java/org/mafagafogigante/dungeon/entity/creatures/SimpleAttackAlgorithm.java
+++ b/src/main/java/org/mafagafogigante/dungeon/entity/creatures/SimpleAttackAlgorithm.java
@@ -57,6 +57,8 @@ class SimpleAttackAlgorithm implements AttackAlgorithm {
       }
       // Decrement the health of the defender.
       defender.getHealth().decrementBy(damage);
+      attacker.getBattleDamage().incrementInflicted(damage);
+      defender.getBattleDamage().incrementReceived(damage);
       AttackAlgorithmWriter.writeInflictedDamage(attacker, damage, defender, isCriticalHit);
       // Respect the contract: If the defender is dead, set its cause of death.
       if (defender.getHealth().isDead()) {

--- a/src/main/java/org/mafagafogigante/dungeon/game/Engine.java
+++ b/src/main/java/org/mafagafogigante/dungeon/game/Engine.java
@@ -139,6 +139,10 @@ public final class Engine {
       PartOfDay partOfDay = PartOfDay.getCorrespondingConstant(Game.getGameState().getWorld().getWorldDate());
       Game.getGameState().getStatistics().getBattleStatistics().addBattle(foe, defeated.getCauseOfDeath(), partOfDay);
       Game.getGameState().getStatistics().getExplorationStatistics().addKill(hero.getLocation().getPoint());
+      final long heroReceivedDamage = hero.getBattleDamage().getAndResetReceivedCount();
+      final long heroInflictedDamage = hero.getBattleDamage().getAndResetInflictedCount();
+      Game.getGameState().getStatistics().getHeroStatistics().incrementDamageReceivedCount(heroReceivedDamage);
+      Game.getGameState().getStatistics().getHeroStatistics().incrementDamageInflictedCount(heroInflictedDamage);
     }
   }
 

--- a/src/main/java/org/mafagafogigante/dungeon/stats/HeroStatistics.java
+++ b/src/main/java/org/mafagafogigante/dungeon/stats/HeroStatistics.java
@@ -1,0 +1,56 @@
+package org.mafagafogigante.dungeon.stats;
+
+import java.io.Serializable;
+
+/**
+ * HeroStatistics class that tracks the Hero's state statistics.
+ */
+public final class HeroStatistics implements Serializable {
+
+  private long sleepTimeCount;
+  private long damageReceivedCount;
+  private long damageInflictedCount;
+  private long restTimeCount;
+  private long healByEatCount;
+
+  public void incrementDamageInflictedCount(long damage) {
+    damageInflictedCount += damage;
+  }
+
+  public void incrementDamageReceivedCount(long damage) {
+    damageReceivedCount += damage;
+  }
+
+  public void incrementRestTimeCount(long resting) {
+    restTimeCount += resting;
+  }
+
+  public void incrementHealByEatCount(long healing) {
+    healByEatCount += healing;
+  }
+
+  public void incrementSleepTimeCount(long sleepTime) {
+    sleepTimeCount += sleepTime;
+  }
+
+  public long getSleepTimeCount() {
+    return sleepTimeCount;
+  }
+
+  public long getDamageReceivedCount() {
+    return damageReceivedCount;
+  }
+
+  public long getDamageInflictedCount() {
+    return damageInflictedCount;
+  }
+
+  public long getRestTimeCount() {
+    return restTimeCount;
+  }
+
+  public long getHealByEatCount() {
+    return healByEatCount;
+  }
+
+}

--- a/src/main/java/org/mafagafogigante/dungeon/stats/Statistics.java
+++ b/src/main/java/org/mafagafogigante/dungeon/stats/Statistics.java
@@ -1,6 +1,7 @@
 package org.mafagafogigante.dungeon.stats;
 
 import org.mafagafogigante.dungeon.commands.IssuedCommand;
+import org.mafagafogigante.dungeon.date.Date;
 import org.mafagafogigante.dungeon.io.Writer;
 import org.mafagafogigante.dungeon.util.Table;
 
@@ -17,6 +18,7 @@ public final class Statistics implements Serializable {
   private final ExplorationStatistics explorationStatistics = new ExplorationStatistics();
   private final BattleStatistics battleStatistics = new BattleStatistics();
   private final CommandStatistics commandStatistics = new CommandStatistics();
+  private final HeroStatistics heroStatistics = new HeroStatistics();
 
   /**
    * Returns the WorldStatistics object of this Statistics.
@@ -41,6 +43,15 @@ public final class Statistics implements Serializable {
   }
 
   /**
+   * Returns the HeroStatistics object of this Statistics.
+   *
+   * @return a HeroStatistics object.
+   */
+  public HeroStatistics getHeroStatistics() {
+    return heroStatistics;
+  }
+
+  /**
    * Adds an issued command to the CommandStatistics.
    */
   public void addCommand(IssuedCommand issuedCommand) {
@@ -54,8 +65,18 @@ public final class Statistics implements Serializable {
     Table statistics = new Table("Property", "Value");
     insertCommandStatistics(statistics);
     statistics.insertSeparator();
+    insertHeroStatistics(statistics);
+    statistics.insertSeparator();
     insertWorldStatistics(statistics);
     Writer.write(statistics);
+  }
+
+  private void insertHeroStatistics(Table statistics) {
+    statistics.insertRow("Damage received", String.valueOf(heroStatistics.getDamageReceivedCount()));
+    statistics.insertRow("Damage inflicted", String.valueOf(heroStatistics.getDamageInflictedCount()));
+    statistics.insertRow("Heals restored by eating", String.valueOf(heroStatistics.getHealByEatCount()));
+    statistics.insertRow("Rested time", new Date(heroStatistics.getRestTimeCount()).toTimeString());
+    statistics.insertRow("Slept time", new Date(heroStatistics.getSleepTimeCount()).toTimeString());
   }
 
   private void insertCommandStatistics(Table statistics) {

--- a/src/test/java/org/mafagafogigante/dungeon/entity/creatures/CreatureBattleDamageTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/entity/creatures/CreatureBattleDamageTest.java
@@ -1,0 +1,22 @@
+package org.mafagafogigante.dungeon.entity.creatures;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CreatureBattleDamageTest {
+
+  @Test
+  public void shouldResetCountersAfterGet() {
+    final CreatureBattleDamage creatureBattleDamage = new CreatureBattleDamage();
+    final long zeroValue = 0L;
+    final long inflictedDamage = 3L;
+    final long receivedDamage = 4L;
+    creatureBattleDamage.incrementInflicted(inflictedDamage);
+    creatureBattleDamage.incrementReceived(receivedDamage);
+    Assert.assertEquals(inflictedDamage, creatureBattleDamage.getAndResetInflictedCount());
+    Assert.assertEquals(zeroValue, creatureBattleDamage.getAndResetInflictedCount());
+    Assert.assertEquals(receivedDamage, creatureBattleDamage.getAndResetReceivedCount());
+    Assert.assertEquals(zeroValue, creatureBattleDamage.getAndResetReceivedCount());
+  }
+
+}

--- a/src/test/java/org/mafagafogigante/dungeon/stats/HeroStatisticsTest.java
+++ b/src/test/java/org/mafagafogigante/dungeon/stats/HeroStatisticsTest.java
@@ -1,0 +1,33 @@
+package org.mafagafogigante.dungeon.stats;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HeroStatisticsTest {
+
+  @Test
+  public void shouldIncrementStatisticValues() {
+    final HeroStatistics heroStatistics = new HeroStatistics();
+    final long damageInflictedValue = 3L;
+    final long damageReceivedValue = 4L;
+    final long healByEatValue = 5L;
+    final long restTimeValue = 6L;
+    final long sleepTimeValue = 7L;
+    heroStatistics.incrementDamageInflictedCount(damageInflictedValue);
+    heroStatistics.incrementDamageInflictedCount(damageInflictedValue);
+    heroStatistics.incrementDamageReceivedCount(damageReceivedValue);
+    heroStatistics.incrementDamageReceivedCount(damageReceivedValue);
+    heroStatistics.incrementHealByEatCount(healByEatValue);
+    heroStatistics.incrementHealByEatCount(healByEatValue);
+    heroStatistics.incrementRestTimeCount(restTimeValue);
+    heroStatistics.incrementRestTimeCount(restTimeValue);
+    heroStatistics.incrementSleepTimeCount(sleepTimeValue);
+    heroStatistics.incrementSleepTimeCount(sleepTimeValue);
+    Assert.assertEquals(damageInflictedValue + damageInflictedValue, heroStatistics.getDamageInflictedCount());
+    Assert.assertEquals(damageReceivedValue + damageReceivedValue, heroStatistics.getDamageReceivedCount());
+    Assert.assertEquals(healByEatValue + healByEatValue, heroStatistics.getHealByEatCount());
+    Assert.assertEquals(restTimeValue + restTimeValue, heroStatistics.getRestTimeCount());
+    Assert.assertEquals(sleepTimeValue + sleepTimeValue, heroStatistics.getSleepTimeCount());
+  }
+
+}


### PR DESCRIPTION
PR is related to the task #104. 
The main changes are related to the `Engine` class and I planned to provide some tests for it, but looks like we need #170 first (`Engine` depends on `GameState` which is connected with `main` method).

Hero statistics block is available using next game command `extra statistics`.